### PR TITLE
Fix deletion of admin users or their domains

### DIFF
--- a/include/php/pages/admin/deletedomain.php
+++ b/include/php/pages/admin/deletedomain.php
@@ -18,9 +18,15 @@ if(isset($_POST['confirm'])){
 	$confirm = $_POST['confirm'];
 	
 	if($confirm === "yes"){
+
+		$admin_domains = array();
+		foreach($admins as $admin) {
+			$parts = explode("@", $admin);
+			$admin_domains[] = $parts[1];
+		}
+
 		// Check if admin domain is affected
-		$admin_domain = explode("@", ADMIN_EMAIL)[1];
-		if($admin_domain !== $domain){				
+		if(!in_array($domain, $admin_domains)){
 			$sql = "DELETE FROM `".DBT_DOMAINS."` WHERE `".DBC_DOMAINS_ID."` = '$id'";
 				
 			if(!$result = $db->query($sql)){

--- a/include/php/pages/admin/deleteuser.php
+++ b/include/php/pages/admin/deleteuser.php
@@ -22,7 +22,8 @@ if(isset($_POST['confirm'])){
 	$confirm = $_POST['confirm'];
 	
 	if($confirm === "yes"){
-		if($mailaddress !== ADMIN_EMAIL){
+		// Check if admin is affected
+		if (!in_array($mailaddress, $admins)) {
 			$sql = "DELETE FROM `".DBT_USERS."` WHERE `".DBC_USERS_ID."` = '$id'";
 				
 			if(!$result = $db->query($sql)){


### PR DESCRIPTION
Since the change in 3335c6edce13e89df88be184a1850116625bc236 the deletion of admins was possible again and as mentioned by @lastsamurai26 in #21 this resulted in an php error/notice.

This is the correct fix for the problem though ;)